### PR TITLE
Damage enemy with bullets from player and turrets

### DIFF
--- a/Assets/Models/Bullet.prefab
+++ b/Assets/Models/Bullet.prefab
@@ -110,6 +110,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hitEffect: {fileID: 0}
+  bulletDamage: 25
 --- !u!54 &3833045344010413039
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Models/Towers/Bullet.prefab
+++ b/Assets/Models/Towers/Bullet.prefab
@@ -108,3 +108,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 518e09dd5d31c784badfd69e28d18f01, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  speed: 70
+  bulletDamage: 35

--- a/Assets/Scripts/PlayerBullet.cs
+++ b/Assets/Scripts/PlayerBullet.cs
@@ -5,17 +5,22 @@ using UnityEngine;
 public class PlayerBullet : MonoBehaviour {
 
     public GameObject hitEffect; // TODO: get a hit effect for the bullets
+    [SerializeField] private int bulletDamage;
 
     void Start() {
         //Ignore the collisions between layers "Player" and "PlayerBullets"
         Physics.IgnoreLayerCollision(6, 9);
     }
-    void OnCollisionEnter(Collision collision) {
+    void OnCollisionEnter(Collision other) {
         // TODO: implement hit effect
         // Instantiate(hitEffect, transform.position, Quaternion.identity); // Quaternion.identity is the default rotation
         // Destroy(effect, 5f); // destroy after 5 ticks
+        
+        if (other.collider.CompareTag("Enemy"))
+        {
+            other.collider.GetComponentInParent<Enemy>().TakeDamage(bulletDamage);
+        }
+        
         Destroy(gameObject);
-
-        // TODO: add enemy damage
     }
 }

--- a/Assets/Scripts/Towers/Bullet.cs
+++ b/Assets/Scripts/Towers/Bullet.cs
@@ -7,6 +7,7 @@ public class Bullet : MonoBehaviour
 
     private Transform target;
     public float speed = 70f;
+    [SerializeField] private int bulletDamage;
 
     public void Seek(Transform _target) 
     { 
@@ -16,7 +17,7 @@ public class Bullet : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (target != null) 
+        if (target == null) 
         { 
             Destroy(gameObject);
             return;
@@ -24,11 +25,10 @@ public class Bullet : MonoBehaviour
 
         Vector3 dir = target.position - transform.position;
         float distanceThisFrame = speed * Time.deltaTime;
-
+        
         if (dir.magnitude <= distanceThisFrame)
         {
             HitTarget();
-            return;
         }
 
         transform.Translate(dir.normalized * distanceThisFrame, Space.World);
@@ -36,6 +36,11 @@ public class Bullet : MonoBehaviour
 
     void HitTarget() 
     {
-        Destroy(gameObject);
+        if (target.CompareTag("Enemy"))
+        {
+            target.GetComponent<Enemy>().TakeDamage(bulletDamage);
+        }
+
+        Destroy(gameObject);    // destroys the bullet
     }
 }


### PR DESCRIPTION
#12 
Bullets deals damage. The player's bullets damage enemies based on an `OnCollisionEnter` trigger, i.e. when a bullet actually collides with an enemy. The turret's bullets damage enemies when their distance to their current target <= 0.

In the future, I think we should potentially unify how we deal with triggering damage events to enemies. Especially when we implement other turrets that maybe don't shoot "seeking" bullets, i.e. some AoE turret or the like.

Left some comments in the commits that the reviewers can reflect on.

