### PR TITLE
Make the tower only target enemies that are not hidden in fog. 

### DIFF
--- a/Assets/Models/Enemy/Enemy.prefab
+++ b/Assets/Models/Enemy/Enemy.prefab
@@ -363,21 +363,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 1
   initSpeed: 1
+  health: 0
   initHealth: 100
-  inkGained: 50
   attackBaseDmg: 50
   initAttack: 50
   defense: 0
   initDefense: 10
+  inkGained: 50
   deathEffect: {fileID: 6496939036694839794, guid: fa175d5aa33423f4a9406bdc4bd544aa, type: 3}
-  health: 0
   isScorched: 0
   isChilled: 0
   isDrenched: 0
   isScalded: 0
   isFrozen: 0
   isWeakened: 0
+  isInFog: 1
   healthBar: {fileID: 1929750958}
+  map: {fileID: 0}
 --- !u!114 &5754276524425126750
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Models/Fog.prefab
+++ b/Assets/Models/Fog.prefab
@@ -12,10 +12,12 @@ GameObject:
   - component: {fileID: 1420561545051096228}
   - component: {fileID: 1420561545051096231}
   - component: {fileID: 1420561545051096230}
+  - component: {fileID: 9219249358020065657}
+  - component: {fileID: 5434386130524339628}
   - component: {fileID: 1065614421}
   m_Layer: 10
   m_Name: Fog
-  m_TagString: Untagged
+  m_TagString: Fog
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -96,6 +98,35 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &9219249358020065657
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1420561545051096249}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &5434386130524339628
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1420561545051096249}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!114 &1065614421
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657838, g: 0.49641234, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1245,7 +1245,7 @@ Transform:
   - {fileID: 902795042}
   - {fileID: 1910635611}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1789031183
 MonoBehaviour:
@@ -1929,7 +1929,7 @@ PrefabInstance:
       objectReference: {fileID: 550646146}
     - target: {fileID: 6600273765185839074, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6600273765185839074, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -35,6 +35,7 @@ public class Enemy : MonoBehaviour
     [SerializeField] private bool isScalded = false;   // Serialized for debugging purposes
     [SerializeField] private bool isFrozen = false;   // Serialized for debugging purposes
     [SerializeField] private bool isWeakened = false;   // Serialized for debugging purposes
+    [SerializeField] private bool isInFog = true; // Serialized for debugging purposes
 
     private Transform target;
     private int waypointIndex = 0;
@@ -160,6 +161,11 @@ public class Enemy : MonoBehaviour
         return isWeakened;
     }
 
+    public bool getInFog()
+    {
+        return isInFog;
+    }
+
     // enemy die by physical damage
     void Die ()
     {
@@ -196,6 +202,7 @@ public class Enemy : MonoBehaviour
         {
             GetNextWaypoint();
         }
+        
     }
 
     void GetNextWaypoint()
@@ -218,4 +225,35 @@ public class Enemy : MonoBehaviour
         Destroy(gameObject);
     }
 
+    /*
+     * When entering fog, the enemy is in the fog
+     */
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Fog"))
+        {
+            isInFog = true;
+        }
+    }
+    
+    /*
+     * When moving from fog to fog, the enemy is still in the fog
+     */
+    private void OnTriggerStay(Collider other)
+    {
+        {
+            isInFog = true;
+        }
+    }
+
+    /*
+     * When the enemy leaves a fog and does not immediately go into a new fog block, the boolean is set to false.
+     */
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.CompareTag("Fog"))
+        {
+            isInFog = false;
+        }
+    }
 }

--- a/Assets/Scripts/Towers/Turret.cs
+++ b/Assets/Scripts/Towers/Turret.cs
@@ -67,6 +67,7 @@ public class Turret : MonoBehaviour
         foreach (GameObject enemy in enemies) 
         {
             float distanceToEnemy = Vector3.Distance(transform.position, enemy.transform.position);
+            if (enemy.GetComponent<Enemy>().getInFog()) continue;   // a target is only targeted if it is not in the fog 
             if (distanceToEnemy < shortestDistance)
             {
                 shortestDistance = distanceToEnemy;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Enemy
+  - Fog
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Implemented a quick check for turrets to only shoot at enemies that are not in the fog.

Some notable changes that were needed to get a trigger for entering/staying/leaving fog blocks:
* Fog blocks now have a Rigidbody (kinematic)
* Fog blocks now have a secondary box collider that acts as a trigger

This closes #44 .