### PR TITLE
Make enemies invisible when in fog

### DIFF
--- a/Assets/Models/Fog.prefab
+++ b/Assets/Models/Fog.prefab
@@ -13,9 +13,11 @@ GameObject:
   - component: {fileID: 1065614421}
   - component: {fileID: 6545443886263608466}
   - component: {fileID: 7273338468186218671}
+  - component: {fileID: 7103102860180800649}
+  - component: {fileID: 3853157977233381185}
   m_Layer: 3
   m_Name: Fog
-  m_TagString: Untagged
+  m_TagString: Fog
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -4834,6 +4836,35 @@ ParticleSystemRenderer:
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
   m_MaskInteraction: 0
+--- !u!54 &7103102860180800649
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1420561545051096249}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!65 &3853157977233381185
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1420561545051096249}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.5, z: 1}
+  m_Center: {x: 0, y: 0.75, z: 0}
 --- !u!1 &7263232860982661987
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -32,6 +32,9 @@ public class Enemy : MonoBehaviour
     [SerializeField] private bool isScalded = false;   // Serialized for debugging purposes
     [SerializeField] private bool isFrozen = false;   // Serialized for debugging purposes
     [SerializeField] private bool isWeakened = false;   // Serialized for debugging purposes
+    public bool isInFog = true;
+    private MeshRenderer ballMeshRenderer;
+    private Transform ballParentTransform;
 
     private Transform target;
     private int waypointIndex = 0;
@@ -160,6 +163,11 @@ public class Enemy : MonoBehaviour
         return isWeakened;
     }
 
+    public bool getInFog()
+    {
+        return isInFog;
+    }
+
     void Die ()
     {
         // add ink
@@ -183,6 +191,9 @@ public class Enemy : MonoBehaviour
         defense = initDefense;
         bulletPrefab = GetComponentInParent<EnemyShooting>().bulletPrefab;
 
+        ballMeshRenderer = gameObject.GetComponent<MeshRenderer>();
+        ballParentTransform = gameObject.transform;
+
         // first target, which is first waypoint in Waypoints
         target = Waypoints.points[0];
     }
@@ -205,6 +216,9 @@ public class Enemy : MonoBehaviour
         {
             GetNextWaypoint();
         }
+        
+        // enemy is visible if not in fog, hence its visibility is the negation of the isInFog bool.
+        setEnemyVisibility(!isInFog);
     }
 
     void GetNextWaypoint()
@@ -222,6 +236,48 @@ public class Enemy : MonoBehaviour
     void EndPath()
     {
         // do nothing
+    }
+    
+    /*
+     * When entering fog, the enemy is in the fog
+     */
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Fog"))
+        {
+            isInFog = true;
+        }
+    }
+
+    /*
+     * When moving from fog to fog, the enemy is still in the fog
+     */
+    private void OnTriggerStay(Collider other)
+    {
+         if (other.CompareTag("Fog"))
+         {
+             isInFog = true;
+         }
+    }
+
+    /*
+     * When the enemy leaves a fog and does not immediately go into a new fog block, the boolean is set to false.
+     */
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.CompareTag("Fog"))
+        {
+            isInFog = false;
+        }
+    }
+
+    private void setEnemyVisibility(bool isVisible)
+    {
+        ballMeshRenderer.enabled = isVisible;
+        foreach (Transform childrenTransform in ballParentTransform)
+        {
+            childrenTransform.gameObject.SetActive(isVisible);
+        }
     }
 
 }


### PR DESCRIPTION
Makes the enemies invisible when they are in the fog. Disables the mesh renderer of the enemy's sphere, and `setActive(false)` for all the enemy's children, like their canvas and their little pipe. Hence, all mechanics attached to the enemy is still working, like taking damage etc., it's just not rendered. 

Closes #67 