### PR TITLE
Small fix for a bug with the melee atk

### DIFF
--- a/Assets/Scripts/Player/PlayerMeleeHitbox.cs
+++ b/Assets/Scripts/Player/PlayerMeleeHitbox.cs
@@ -44,6 +44,7 @@ public class PlayerMeleeHitbox : MonoBehaviour
         }
 
         foreach (Collider collider in colliderList) {
+            if (!collider) continue;    // should not continue if the game object has already been destroyed.
             if (collider.CompareTag("Enemy")) {
                 // TODO: implement hit effect
                 // Instantiate(hitEffect, transform.position, Quaternion.identity); // Quaternion.identity is the default rotation


### PR DESCRIPTION
<img width="623" alt="Screenshot 2022-03-27 at 1 42 14 PM" src="https://user-images.githubusercontent.com/72025352/160269089-93ee1a0b-fcd9-4210-bc02-acebe4a5c559.png">

Just a very small one-line fix for the bug where an enemy would be destroyed before the melee attack starts incurring damage. Added a little check to verify that the enemy's collider still exists. 

The original error is caused by the delay from when an enemy is hit by the melee attack's hitbox and when this hit actually would inflict damage. This PR fixes this by adding an additional check.

Closes #61 
