### PR TITLE
Enemy fog triggers

### DIFF
--- a/Assets/Models/Fog.prefab
+++ b/Assets/Models/Fog.prefab
@@ -13,8 +13,6 @@ GameObject:
   - component: {fileID: 1065614421}
   - component: {fileID: 6545443886263608466}
   - component: {fileID: 7273338468186218671}
-  - component: {fileID: 7103102860180800649}
-  - component: {fileID: 3853157977233381185}
   m_Layer: 3
   m_Name: Fog
   m_TagString: Fog
@@ -4836,35 +4834,6 @@ ParticleSystemRenderer:
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
   m_MaskInteraction: 0
---- !u!54 &7103102860180800649
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1420561545051096249}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!65 &3853157977233381185
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1420561545051096249}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1.5, z: 1}
-  m_Center: {x: 0, y: 0.75, z: 0}
 --- !u!1 &7263232860982661987
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Map/MapGenerator.cs
+++ b/Assets/Scripts/Map/MapGenerator.cs
@@ -458,6 +458,11 @@ public class MapGenerator : MonoBehaviour
         return basePosition - delta;
     }
 
+    public Cell[,] GetCells()
+    {
+        return cells;
+    }
+
     /* Grid pattern to visualize Map in editor mode.
     */
     private void OnDrawGizmos() {


### PR DESCRIPTION
I've changed the mechanics for detecting if enemies are in fog or not. The new version is based on using the information of the tile whenever an enemy moves from one tile to another. Hence, triggers are no longer used and colliders will have no impact on if an enemy is in fog or not. It will only change when an enemy's `Math.Floor(xPosition)` and `Math.Floor(zPosition)` changes from one integer to another, which will trigger a check to see if the new positions correspond to a foggy tile or not.

Closes #78 .