### PR TITLE
Hide tooltip on button down

### DIFF
--- a/Assets/Scripts/UI/Tooltip/TooltipTrigger.cs
+++ b/Assets/Scripts/UI/Tooltip/TooltipTrigger.cs
@@ -1,15 +1,16 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
-public class TooltipTrigger : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+public class TooltipTrigger : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler
 {    
     [SerializeField] private string header;
     
     [Multiline]
     [SerializeField] private string content;
-
     
     public void OnPointerEnter(PointerEventData eventData)
     {
@@ -18,6 +19,12 @@ public class TooltipTrigger : MonoBehaviour, IPointerEnterHandler, IPointerExitH
 
     public void OnPointerExit(PointerEventData eventData)
     {
+        TooltipSystem.Hide();
+    }
+    
+    public void OnPointerDown(PointerEventData eventData)
+    {
+        // in-case we click the button, we can hide the tooltip again. For example if we click a button.
         TooltipSystem.Hide();
     }
 }


### PR DESCRIPTION
Quick fix for tooltip not being hidden after pressing a button in the `NodeUI`. This was solved by adding an event handler for button down in the `TooltipTrigger` script.

Closes #102 