### PR TITLE
Fix bug for water elements and its combination

### DIFF
--- a/Assets/ScriptableObjects/Elements/ElementInfos/WaterElement.asset
+++ b/Assets/ScriptableObjects/Elements/ElementInfos/WaterElement.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: WaterElement
   m_EditorClassIdentifier: 
   type: 2
-  effect: {fileID: 11400000, guid: 3736ed5fb54fd314eb72776659995569, type: 2}
+  effect: {fileID: 11400000, guid: a620402c788011848a12b7a2ef9ad464, type: 2}


### PR DESCRIPTION
In `directory-structure` branch,

`WaterElement` effect should be decreasing enemy's attack. But is decreasing enemy's def in this branch. Causing all the combined effect to be wrong. Fixed by assigning `AtkDecreEffect` to `WaterElement`.

For newcomer,

Water: atk decrease
Ice: speed decrease
Fire: dot (damage over time)
Water + Fire: burst dot
Water + Ice: enemy freeze
Fire + Ice:  def decrease
Can refer to in-game `Guide` too