### PR TITLE
Refactor `effect status` for enemy

### DIFF
--- a/Assets/ScriptableObjects/Elements/ElementInfos/WaterElement.asset
+++ b/Assets/ScriptableObjects/Elements/ElementInfos/WaterElement.asset
@@ -13,4 +13,4 @@ MonoBehaviour:
   m_Name: WaterElement
   m_EditorClassIdentifier: 
   type: 2
-  effect: {fileID: 11400000, guid: 3736ed5fb54fd314eb72776659995569, type: 2}
+  effect: {fileID: 11400000, guid: a620402c788011848a12b7a2ef9ad464, type: 2}

--- a/Assets/Scripts/ElementEffectSystem/EffectManager.cs
+++ b/Assets/Scripts/ElementEffectSystem/EffectManager.cs
@@ -69,13 +69,13 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
     private void setWeakenedData() {
         RemoveEffect();
-        enemy.setEffectStatus(Enemy.EffectStatus.WEAKEN);
+        enemy.setEffectStatus(EffectStatus.WEAKEN);
         this._data = _weakenedData;
     }
 
     private void setScaldedData() {
         RemoveEffect();
-        enemy.setEffectStatus(Enemy.EffectStatus.SCALD);
+        enemy.setEffectStatus(EffectStatus.SCALD);
         this._data = _scaldedData;
 
         // Info for burstDot effect
@@ -84,7 +84,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
     private void setFrozenData() {
         RemoveEffect();
-        enemy.setEffectStatus(Enemy.EffectStatus.FROZE);
+        enemy.setEffectStatus(EffectStatus.FROZE);
         this._data = _frozenData;
     }
 
@@ -97,23 +97,23 @@ public class EffectManager : MonoBehaviour, IEffectable {
     }
 
     public void RemoveEffect() {
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.CHILL) {
+        if (enemy.getEffectStatus() == EffectStatus.CHILL) {
             enemy.RestoreSpeed();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.DRENCH) {
+        if (enemy.getEffectStatus() == EffectStatus.DRENCH) {
             enemy.RestoreAttack();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.FROZE) {
+        if (enemy.getEffectStatus() == EffectStatus.FROZE) {
             enemy.RestoreSpeed();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.WEAKEN) {
+        if (enemy.getEffectStatus() == EffectStatus.WEAKEN) {
             enemy.RestoreDefense();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.SCALD) {
+        if (enemy.getEffectStatus() == EffectStatus.SCALD) {
             enemy.removeEffectStatus();
         }
 
@@ -136,7 +136,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
         // Update status effect timer accordingly
         // Frozen Effect (Ice + Water)
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.FROZE && _currentEffectTime > _nextTickTime) {
+        if (enemy.getEffectStatus() == EffectStatus.FROZE && _currentEffectTime > _nextTickTime) {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(0);
@@ -144,14 +144,14 @@ public class EffectManager : MonoBehaviour, IEffectable {
             _nextTickTime += _data.TickSpeed;
         }
         // BurstDOT Effect (Fire + Water)
-        else if (enemy.getEffectStatus() == Enemy.EffectStatus.SCALD && _currentEffectTime > _nextTickTime) {
+        else if (enemy.getEffectStatus() == EffectStatus.SCALD && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.TakeDot(_data.DOTAmount * _data.TickSpeed * _data.Lifetime);
             }
             _nextTickTime += _data.TickSpeed;
         }
         // DefDecre Effect (Ice + Fire)
-        else if (enemy.getEffectStatus() == Enemy.EffectStatus.WEAKEN && _currentEffectTime > _nextTickTime) {
+        else if (enemy.getEffectStatus() == EffectStatus.WEAKEN && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.ReduceDefense(_data.DefDecreAmount);
             }
@@ -166,7 +166,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
         else if (_data.SlowAmount != 0 && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(_data.SlowAmount);
-                enemy.setEffectStatus(Enemy.EffectStatus.CHILL);
+                enemy.setEffectStatus(EffectStatus.CHILL);
             }
             _nextTickTime += _data.TickSpeed;
         }
@@ -174,7 +174,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
         else if (_data.AtkDecreAmount != 0 && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.ReduceAttack(_data.AtkDecreAmount);
-                enemy.setEffectStatus(Enemy.EffectStatus.DRENCH);
+                enemy.setEffectStatus(EffectStatus.DRENCH);
             }
             _nextTickTime += _data.TickSpeed;
         }

--- a/Assets/Scripts/ElementEffectSystem/EffectManager.cs
+++ b/Assets/Scripts/ElementEffectSystem/EffectManager.cs
@@ -69,13 +69,13 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
     private void setWeakenedData() {
         RemoveEffect();
-        enemy.setEffectStatus(Enemy.EffectStatus.weaken);
+        enemy.setEffectStatus(Enemy.EffectStatus.WEAKEN);
         this._data = _weakenedData;
     }
 
     private void setScaldedData() {
         RemoveEffect();
-        enemy.setEffectStatus(Enemy.EffectStatus.scald);
+        enemy.setEffectStatus(Enemy.EffectStatus.SCALD);
         this._data = _scaldedData;
 
         // Info for burstDot effect
@@ -84,7 +84,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
     private void setFrozenData() {
         RemoveEffect();
-        enemy.setEffectStatus(Enemy.EffectStatus.froze);
+        enemy.setEffectStatus(Enemy.EffectStatus.FROZE);
         this._data = _frozenData;
     }
 
@@ -97,23 +97,23 @@ public class EffectManager : MonoBehaviour, IEffectable {
     }
 
     public void RemoveEffect() {
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.chill) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.CHILL) {
             enemy.RestoreSpeed();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.drench) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.DRENCH) {
             enemy.RestoreAttack();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.froze) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.FROZE) {
             enemy.RestoreSpeed();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.weaken) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.WEAKEN) {
             enemy.RestoreDefense();
             enemy.removeEffectStatus();
         }
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.scald) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.SCALD) {
             enemy.removeEffectStatus();
         }
 
@@ -136,7 +136,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
         // Update status effect timer accordingly
         // Frozen Effect (Ice + Water)
-        if (enemy.getEffectStatus() == Enemy.EffectStatus.froze && _currentEffectTime > _nextTickTime) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.FROZE && _currentEffectTime > _nextTickTime) {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(0);
@@ -144,14 +144,14 @@ public class EffectManager : MonoBehaviour, IEffectable {
             _nextTickTime += _data.TickSpeed;
         }
         // BurstDOT Effect (Fire + Water)
-        else if (enemy.getEffectStatus() == Enemy.EffectStatus.scald && _currentEffectTime > _nextTickTime) {
+        else if (enemy.getEffectStatus() == Enemy.EffectStatus.SCALD && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.TakeDot(_data.DOTAmount * _data.TickSpeed * _data.Lifetime);
             }
             _nextTickTime += _data.TickSpeed;
         }
         // DefDecre Effect (Ice + Fire)
-        else if (enemy.getEffectStatus() == Enemy.EffectStatus.weaken && _currentEffectTime > _nextTickTime) {
+        else if (enemy.getEffectStatus() == Enemy.EffectStatus.WEAKEN && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.ReduceDefense(_data.DefDecreAmount);
             }
@@ -166,7 +166,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
         else if (_data.SlowAmount != 0 && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(_data.SlowAmount);
-                enemy.setEffectStatus(Enemy.EffectStatus.chill);
+                enemy.setEffectStatus(Enemy.EffectStatus.CHILL);
             }
             _nextTickTime += _data.TickSpeed;
         }
@@ -174,7 +174,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
         else if (_data.AtkDecreAmount != 0 && _currentEffectTime > _nextTickTime) {
             if (_nextTickTime == 0) {
                 enemy.ReduceAttack(_data.AtkDecreAmount);
-                enemy.setEffectStatus(Enemy.EffectStatus.drench);
+                enemy.setEffectStatus(Enemy.EffectStatus.DRENCH);
             }
             _nextTickTime += _data.TickSpeed;
         }

--- a/Assets/Scripts/ElementEffectSystem/EffectManager.cs
+++ b/Assets/Scripts/ElementEffectSystem/EffectManager.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class EffectManager : MonoBehaviour, IEffectable {
@@ -11,7 +9,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
     private float _currentEffectTime = 0f;
     private float _nextTickTime = 0f;
 
-    // For Special Effects
+    // For Combined Effects
     [SerializeField] private ElementEffectInfo _scaldedData;
     [SerializeField] private ElementEffectInfo _frozenData;
     [SerializeField] private ElementEffectInfo _weakenedData;
@@ -19,18 +17,14 @@ public class EffectManager : MonoBehaviour, IEffectable {
     // For Burst DOT Effect
     private float _burstDotAmount;
 
-    // Start is called before the first frame update
     void Start() {
         enemy = GetComponentInParent<Enemy>();
     }
 
-    // Update is called once per frame
     void Update() {
         if (_data != null) HandleEffect();
     }
 
-
-    // Apply Status Effect on enemy
     public void ApplyEffect(ElementEffectInfo _data) {
         // Check if already has 2 elements
         if (_data != null) {
@@ -102,7 +96,6 @@ public class EffectManager : MonoBehaviour, IEffectable {
         }
     }
 
-    // Remove Status Effect on enemy
     public void RemoveEffect() {
         if (enemy.getEffectStatus() == Enemy.EffectStatus.chill) {
             enemy.RestoreSpeed();
@@ -152,7 +145,6 @@ public class EffectManager : MonoBehaviour, IEffectable {
         }
         // BurstDOT Effect (Fire + Water)
         else if (enemy.getEffectStatus() == Enemy.EffectStatus.scald && _currentEffectTime > _nextTickTime) {
-            // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.TakeDot(_data.DOTAmount * _data.TickSpeed * _data.Lifetime);
             }
@@ -160,29 +152,26 @@ public class EffectManager : MonoBehaviour, IEffectable {
         }
         // DefDecre Effect (Ice + Fire)
         else if (enemy.getEffectStatus() == Enemy.EffectStatus.weaken && _currentEffectTime > _nextTickTime) {
-            // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceDefense(_data.DefDecreAmount);
             }
             _nextTickTime += _data.TickSpeed;
         }
-        // DOT Effect
+        // DOT Effect (Fire)
         else if (_data.DOTAmount != 0 && _currentEffectTime > _nextTickTime) {
             _nextTickTime += _data.TickSpeed;
             enemy.TakeDot(_data.DOTAmount);
         }
-        // Slow Effect
+        // Slow Effect (Ice)
         else if (_data.SlowAmount != 0 && _currentEffectTime > _nextTickTime) {
-            // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(_data.SlowAmount);
                 enemy.setEffectStatus(Enemy.EffectStatus.chill);
             }
             _nextTickTime += _data.TickSpeed;
         }
-        // Attack Decrease Effect
+        // Attack Decrease Effect (Water)
         else if (_data.AtkDecreAmount != 0 && _currentEffectTime > _nextTickTime) {
-            // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceAttack(_data.AtkDecreAmount);
                 enemy.setEffectStatus(Enemy.EffectStatus.drench);

--- a/Assets/Scripts/ElementEffectSystem/EffectManager.cs
+++ b/Assets/Scripts/ElementEffectSystem/EffectManager.cs
@@ -74,30 +74,23 @@ public class EffectManager : MonoBehaviour, IEffectable {
     }
 
     private void setWeakenedData() {
-        // enemy.setChilled(true);
-        enemy.setEffectStatus(Enemy.EffectStatus.chill);
-
         RemoveEffect();
-        enemy.setWeakened(true);
+        enemy.setEffectStatus(Enemy.EffectStatus.weaken);
         this._data = _weakenedData;
     }
 
     private void setScaldedData() {
-        enemy.setDrenched(true);
         RemoveEffect();
-        enemy.setScalded(true);
+        enemy.setEffectStatus(Enemy.EffectStatus.scald);
         this._data = _scaldedData;
+
         // Info for burstDot effect
         this._data.DOTAmount = _burstDotAmount;
     }
 
     private void setFrozenData() {
-        //enemy.setChilled(true);
-        enemy.setEffectStatus(Enemy.EffectStatus.chill);
-
-        enemy.setDrenched(true);
         RemoveEffect();
-        enemy.setFrozen(true);
+        enemy.setEffectStatus(Enemy.EffectStatus.froze);
         this._data = _frozenData;
     }
 
@@ -113,23 +106,22 @@ public class EffectManager : MonoBehaviour, IEffectable {
     public void RemoveEffect() {
         if (enemy.getEffectStatus() == Enemy.EffectStatus.chill) {
             enemy.RestoreSpeed();
-            //enemy.setChilled(false);
             enemy.removeEffectStatus();
         }
-        if (enemy.getDrenched()) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.drench) {
             enemy.RestoreAttack();
-            enemy.setDrenched(false);
+            enemy.removeEffectStatus();
         }
-        if (enemy.getFrozen()) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.froze) {
             enemy.RestoreSpeed();
-            enemy.setFrozen(false);
+            enemy.removeEffectStatus();
         }
-        if (enemy.getWeakened()) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.weaken) {
             enemy.RestoreDefense();
-            enemy.setWeakened(false);
+            enemy.removeEffectStatus();
         }
-        if (enemy.getScalded()) {
-            enemy.setScalded(false);
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.scald) {
+            enemy.removeEffectStatus();
         }
 
         _data = null;
@@ -151,7 +143,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
 
         // Update status effect timer accordingly
         // Frozen Effect (Ice + Water)
-        if (enemy.getFrozen() && _currentEffectTime > _nextTickTime) {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.froze && _currentEffectTime > _nextTickTime) {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(0);
@@ -159,7 +151,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
             _nextTickTime += _data.TickSpeed;
         }
         // BurstDOT Effect (Fire + Water)
-        else if (enemy.getScalded() && _currentEffectTime > _nextTickTime) {
+        else if (enemy.getEffectStatus() == Enemy.EffectStatus.scald && _currentEffectTime > _nextTickTime) {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.TakeDot(_data.DOTAmount * _data.TickSpeed * _data.Lifetime);
@@ -167,7 +159,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
             _nextTickTime += _data.TickSpeed;
         }
         // DefDecre Effect (Ice + Fire)
-        else if (enemy.getWeakened() && _currentEffectTime > _nextTickTime) {
+        else if (enemy.getEffectStatus() == Enemy.EffectStatus.weaken && _currentEffectTime > _nextTickTime) {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceDefense(_data.DefDecreAmount);
@@ -184,7 +176,6 @@ public class EffectManager : MonoBehaviour, IEffectable {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(_data.SlowAmount);
-                //enemy.setChilled(true);
                 enemy.setEffectStatus(Enemy.EffectStatus.chill);
             }
             _nextTickTime += _data.TickSpeed;
@@ -194,7 +185,7 @@ public class EffectManager : MonoBehaviour, IEffectable {
             // Only triggered once
             if (_nextTickTime == 0) {
                 enemy.ReduceAttack(_data.AtkDecreAmount);
-                enemy.setDrenched(true);
+                enemy.setEffectStatus(Enemy.EffectStatus.drench);
             }
             _nextTickTime += _data.TickSpeed;
         }

--- a/Assets/Scripts/ElementEffectSystem/EffectManager.cs
+++ b/Assets/Scripts/ElementEffectSystem/EffectManager.cs
@@ -2,10 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class EffectManager : MonoBehaviour, IEffectable
-{
+public class EffectManager : MonoBehaviour, IEffectable {
     private Enemy enemy;
-    
+
     // For Status Effects
     private ElementEffectInfo _data;
     private GameObject _effectParticles;
@@ -21,79 +20,69 @@ public class EffectManager : MonoBehaviour, IEffectable
     private float _burstDotAmount;
 
     // Start is called before the first frame update
-    void Start()
-    {
+    void Start() {
         enemy = GetComponentInParent<Enemy>();
     }
 
     // Update is called once per frame
-    void Update()
-    {
+    void Update() {
         if (_data != null) HandleEffect();
     }
 
 
     // Apply Status Effect on enemy
-    public void ApplyEffect(ElementEffectInfo _data)
-    {
+    public void ApplyEffect(ElementEffectInfo _data) {
         // Check if already has 2 elements
         if (_data != null) {
             // Enemy is already inflicted with a status effect
-            if (this._data != null)     
-            {
+            if (this._data != null) {
                 // Enemy is already inflicted with elemental reaction effect
-                if (this._data.Element == "Combined")
-                {
+                if (this._data.Element == "Combined") {
                     return;
                 }
 
                 // Different element is inflicted on enemy
-                if (this._data.Element != _data.Element)
-                {
+                if (this._data.Element != _data.Element) {
                     // Frozen
-                    if ((this._data.Element == "Ice" && _data.Element == "Water") || (this._data.Element == "Water" && _data.Element == "Ice"))
-                    {
+                    if ((this._data.Element == "Ice" && _data.Element == "Water") || (this._data.Element == "Water" && _data.Element == "Ice")) {
                         setFrozenData();
                     }
                     // Scalded
-                    else if (this._data.Element == "Fire" && _data.Element == "Water" || this._data.Element == "Water" && _data.Element == "Fire")
-                    {
+                    else if (this._data.Element == "Fire" && _data.Element == "Water" || this._data.Element == "Water" && _data.Element == "Fire") {
                         setBurstDOTAmount(_data);
                         setScaldedData();
                     }
                     // Weakened
-                    else if (this._data.Element == "Ice" && _data.Element == "Fire" || this._data.Element == "Fire" && _data.Element == "Ice")
-                    {
+                    else if (this._data.Element == "Ice" && _data.Element == "Fire" || this._data.Element == "Fire" && _data.Element == "Ice") {
                         setWeakenedData();
                     }
                 }
                 // Same element is inflicted on enemy
-                else
-                {
+                else {
                     RemoveEffect();
                     this._data = _data;
                 }
             }
             // Enemy not inflicted with status effect yet
-            else 
+            else
                 this._data = _data;
 
             // Spawn particle effects for elements and elemental reactions
             _effectParticles = Instantiate(this._data.EffectParticles, transform);
-            
+
         }
     }
 
-    private void setWeakenedData()
-    {
-        enemy.setChilled(true);
+    private void setWeakenedData() {
+        // enemy.setChilled(true);
+        enemy.setEffectStatus(Enemy.EffectStatus.chill);
+
         RemoveEffect();
         enemy.setWeakened(true);
         this._data = _weakenedData;
     }
 
-    private void setScaldedData()
-    {
+    private void setScaldedData() {
         enemy.setDrenched(true);
         RemoveEffect();
         enemy.setScalded(true);
@@ -102,52 +91,44 @@ public class EffectManager : MonoBehaviour, IEffectable
         this._data.DOTAmount = _burstDotAmount;
     }
 
-    private void setFrozenData()
-    {
-        enemy.setChilled(true);
+    private void setFrozenData() {
+        //enemy.setChilled(true);
+        enemy.setEffectStatus(Enemy.EffectStatus.chill);
+
         enemy.setDrenched(true);
         RemoveEffect();
         enemy.setFrozen(true);
         this._data = _frozenData;
     }
 
-    private void setBurstDOTAmount(ElementEffectInfo _data)
-    {
-        if (this._data.Element == "Fire")
-        {
+    private void setBurstDOTAmount(ElementEffectInfo _data) {
+        if (this._data.Element == "Fire") {
             _burstDotAmount = this._data.DOTAmount * this._data.TickSpeed * this._data.Lifetime;
-        }
-        else if (_data.Element == "Fire")
-        {
+        } else if (_data.Element == "Fire") {
             _burstDotAmount = _data.DOTAmount * _data.TickSpeed * _data.Lifetime;
         }
     }
 
     // Remove Status Effect on enemy
-    public void RemoveEffect()
-    {
-        if (enemy.getChilled())
-        {
+    public void RemoveEffect() {
+        if (enemy.getEffectStatus() == Enemy.EffectStatus.chill) {
             enemy.RestoreSpeed();
-            enemy.setChilled(false);
+            //enemy.setChilled(false);
+            enemy.removeEffectStatus();
         }
-        if (enemy.getDrenched())
-        {
+        if (enemy.getDrenched()) {
             enemy.RestoreAttack();
             enemy.setDrenched(false);
         }
-        if (enemy.getFrozen())
-        {
+        if (enemy.getFrozen()) {
             enemy.RestoreSpeed();
             enemy.setFrozen(false);
         }
-        if (enemy.getWeakened())
-        {
+        if (enemy.getWeakened()) {
             enemy.RestoreDefense();
             enemy.setWeakened(false);
         }
-        if (enemy.getScalded())
-        {
+        if (enemy.getScalded()) {
             enemy.setScalded(false);
         }
 
@@ -158,8 +139,7 @@ public class EffectManager : MonoBehaviour, IEffectable
     }
 
     // Handle Status Effect Updates
-    public void HandleEffect()
-    {
+    public void HandleEffect() {
         // Update current effect's time
         _currentEffectTime += Time.deltaTime;
 
@@ -171,58 +151,48 @@ public class EffectManager : MonoBehaviour, IEffectable
 
         // Update status effect timer accordingly
         // Frozen Effect (Ice + Water)
-        if (enemy.getFrozen() && _currentEffectTime > _nextTickTime)
-        {
+        if (enemy.getFrozen() && _currentEffectTime > _nextTickTime) {
             // Only triggered once
-            if (_nextTickTime == 0)
-            {
+            if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(0);
             }
             _nextTickTime += _data.TickSpeed;
         }
         // BurstDOT Effect (Fire + Water)
-        else if (enemy.getScalded() && _currentEffectTime > _nextTickTime)
-        {
+        else if (enemy.getScalded() && _currentEffectTime > _nextTickTime) {
             // Only triggered once
-            if (_nextTickTime == 0)
-            {
+            if (_nextTickTime == 0) {
                 enemy.TakeDot(_data.DOTAmount * _data.TickSpeed * _data.Lifetime);
             }
             _nextTickTime += _data.TickSpeed;
         }
         // DefDecre Effect (Ice + Fire)
-        else if (enemy.getWeakened() && _currentEffectTime > _nextTickTime)
-        {
+        else if (enemy.getWeakened() && _currentEffectTime > _nextTickTime) {
             // Only triggered once
-            if (_nextTickTime == 0)
-            {
+            if (_nextTickTime == 0) {
                 enemy.ReduceDefense(_data.DefDecreAmount);
             }
             _nextTickTime += _data.TickSpeed;
         }
         // DOT Effect
-        else if (_data.DOTAmount != 0 && _currentEffectTime > _nextTickTime)
-        {
+        else if (_data.DOTAmount != 0 && _currentEffectTime > _nextTickTime) {
             _nextTickTime += _data.TickSpeed;
             enemy.TakeDot(_data.DOTAmount);
         }
         // Slow Effect
-        else if (_data.SlowAmount != 0 && _currentEffectTime > _nextTickTime)
-        {
+        else if (_data.SlowAmount != 0 && _currentEffectTime > _nextTickTime) {
             // Only triggered once
-            if (_nextTickTime == 0)
-            {
+            if (_nextTickTime == 0) {
                 enemy.ReduceSpeed(_data.SlowAmount);
-                enemy.setChilled(true);
+                //enemy.setChilled(true);
+                enemy.setEffectStatus(Enemy.EffectStatus.chill);
             }
             _nextTickTime += _data.TickSpeed;
         }
         // Attack Decrease Effect
-        else if (_data.AtkDecreAmount != 0 && _currentEffectTime > _nextTickTime)
-        {
+        else if (_data.AtkDecreAmount != 0 && _currentEffectTime > _nextTickTime) {
             // Only triggered once
-            if (_nextTickTime == 0)
-            {
+            if (_nextTickTime == 0) {
                 enemy.ReduceAttack(_data.AtkDecreAmount);
                 enemy.setDrenched(true);
             }

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -216,7 +216,7 @@ public class Enemy : MonoBehaviour {
         return cell.isFog;
     }
 
-    void GetNextWaypoint() {
+    private void GetNextWaypoint() {
         if (waypointIndex >= Waypoints.points.Length - 1) {
             EndPath();
             return;

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -225,7 +225,7 @@ public class Enemy : MonoBehaviour {
         target = Waypoints.points[waypointIndex];
     }
 
-    void EndPath() {
+    private void EndPath() {
         animator.SetBool("isWalking", false);
     }
 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -25,13 +25,37 @@ public class Enemy : MonoBehaviour {
     private InkManager inkManager;
 
     // Flags for status effects
+    public enum EffectStatus {
+        scorch, // fire
+        chill, // ice
+        drench, // water
+        scald, // fire + water
+        froze, // ice + water
+        weakened, // fire + ice
+        none // default
+    }
 
-    private bool isScorched = false;
-    private bool isChilled = false;
-    private bool isDrenched = false;
-    private bool isScalded = false;
-    private bool isFrozen = false;
-    private bool isWeakened = false;
+    public EffectStatus effectStatus = EffectStatus.none;
+
+    public void setEffectStatus(EffectStatus status) {
+        effectStatus = status;
+    }
+
+    public EffectStatus getEffectStatus() {
+        return effectStatus;
+    }
+
+    public void removeEffectStatus() {
+        effectStatus = EffectStatus.none;
+    }
+
+
+    private bool isScorched = false; // fire: burnt
+    private bool isChilled = false; // ice
+    private bool isDrenched = false; // water: wet
+    private bool isScalded = false; // fire + water: vaporize
+    private bool isFrozen = false; // ice + water
+    private bool isWeakened = false; // fire + ice: melt
 
     public bool isInFog = true;
     //private MeshRenderer ballMeshRenderer;
@@ -104,14 +128,6 @@ public class Enemy : MonoBehaviour {
         defense = initDefense;
     }
 
-    public void setScorched(bool b) {
-        isScorched = b;
-    }
-
-    public bool getScorched() {
-        return isScorched;
-    }
-
     public void setChilled(bool b) {
         isChilled = b;
     }
@@ -150,10 +166,6 @@ public class Enemy : MonoBehaviour {
 
     public bool getWeakened() {
         return isWeakened;
-    }
-
-    public bool getInFog() {
-        return isInFog;
     }
 
     void Die() {

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -136,7 +136,7 @@ public class Enemy : MonoBehaviour {
 
     }
 
-    void Start() {
+    private void Start() {
         health = initHealth;
         speed = initSpeed;
         defense = initDefense;
@@ -156,7 +156,7 @@ public class Enemy : MonoBehaviour {
     }
 
 
-    void Update() {
+    private void Update() {
         healthText.text = string.Format("{0}", health);
 
         if (health <= 0) {

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -207,7 +207,7 @@ public class Enemy : MonoBehaviour {
         }
 
         // enemy is visible if not in fog, hence its visibility is the negation of the isInFog bool.
-        setEnemyVisibility(!isInFog);
+        SetEnemyVisibility(!isInFog);
 
     }
 
@@ -229,7 +229,7 @@ public class Enemy : MonoBehaviour {
         animator.SetBool("isWalking", false);
     }
 
-    private void setEnemyVisibility(bool isVisible) {
+    private void SetEnemyVisibility(bool isVisible) {
         foreach (Transform childrenTransform in ballParentTransform) {
             // disable canvas
             if (childrenTransform.name == canvas.name)

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 
-public class Enemy : MonoBehaviour
-{
+public class Enemy : MonoBehaviour {
 
     [SerializeField] private float speed;               // Serialized for debugging purposes
 
@@ -35,7 +32,7 @@ public class Enemy : MonoBehaviour
     private bool isScalded = false;
     private bool isFrozen = false;
     private bool isWeakened = false;
-   
+
     public bool isInFog = true;
     //private MeshRenderer ballMeshRenderer;
     private Transform ballParentTransform;
@@ -45,14 +42,14 @@ public class Enemy : MonoBehaviour
 
     private int lastXCoord = 0;
     private int lastYCoord = 0;
-    
+
     // to reduce bullet damage
     private GameObject bulletPrefab;
 
     [Header("Unity Stuff")]
     public Image healthBar;
     public TMP_Text healthText;
-    
+
     public MapGenerator map;
     private Cell[,] cells;
 
@@ -64,11 +61,9 @@ public class Enemy : MonoBehaviour
         inkManager = InkManager.instance;
     }
 
-    public void TakeDamage(float amount)
-    {
+    public void TakeDamage(float amount) {
         // Damage to be taken is higher than defense
-        if (defense < amount)
-        {
+        if (defense < amount) {
             health = health - amount + defense;
         }
 
@@ -76,8 +71,7 @@ public class Enemy : MonoBehaviour
         healthBar.fillAmount = health / initHealth;
     }
 
-    public void TakeDot(float amount)
-    {
+    public void TakeDot(float amount) {
         health = health - amount;
 
         // float number between 0 and 1
@@ -85,119 +79,98 @@ public class Enemy : MonoBehaviour
 
     }
 
-    public void ReduceSpeed(float slowAmount)
-    {
+    public void ReduceSpeed(float slowAmount) {
         speed = initSpeed * slowAmount;
     }
 
-    public void RestoreSpeed()
-    {
+    public void RestoreSpeed() {
         speed = initSpeed;
     }
 
-    public void ReduceAttack(int atkDecreAmount)
-    {
+    public void ReduceAttack(int atkDecreAmount) {
         bulletPrefab.GetComponent<EnemyBullet>().ReduceBulletDamage(atkDecreAmount);
     }
 
-    public void RestoreAttack()
-    {
+    public void RestoreAttack() {
         bulletPrefab.GetComponent<EnemyBullet>().RestoreBulletDamage();
     }
 
-    public void ReduceDefense(int defDecreAmount)
-    {
+    public void ReduceDefense(int defDecreAmount) {
         if (defDecreAmount > initDefense) defense = 0;
         else defense = initDefense - defDecreAmount;
     }
 
-    public void RestoreDefense()
-    {
+    public void RestoreDefense() {
         defense = initDefense;
     }
 
-    public void setScorched(bool b)
-    {
+    public void setScorched(bool b) {
         isScorched = b;
     }
 
-    public bool getScorched()
-    {
+    public bool getScorched() {
         return isScorched;
     }
 
-    public void setChilled(bool b)
-    {
+    public void setChilled(bool b) {
         isChilled = b;
     }
 
-    public bool getChilled()
-    {
+    public bool getChilled() {
         return isChilled;
     }
 
-    public void setDrenched(bool b)
-    {
+    public void setDrenched(bool b) {
         isDrenched = b;
     }
 
-    public bool getDrenched()
-    {
+    public bool getDrenched() {
         return isDrenched;
     }
 
-    public void setScalded(bool b)
-    {
+    public void setScalded(bool b) {
         isScalded = b;
     }
 
-    public bool getScalded()
-    {
+    public bool getScalded() {
         return isScalded;
     }
 
-    public void setFrozen(bool b)
-    {
+    public void setFrozen(bool b) {
         isFrozen = b;
     }
 
-    public bool getFrozen()
-    {
+    public bool getFrozen() {
         return isFrozen;
     }
 
-    public void setWeakened(bool b)
-    {
+    public void setWeakened(bool b) {
         isWeakened = b;
     }
 
-    public bool getWeakened()
-    {
+    public bool getWeakened() {
         return isWeakened;
     }
 
-    public bool getInFog()
-    {
+    public bool getInFog() {
         return isInFog;
     }
 
-    void Die ()
-    {
+    void Die() {
         // add ink
         inkManager.ChangeInkAmount(inkGained);
 
         // for new wave
         WaveSpawner.numEnemiesAlive--;
         WaveSpawner.numEnemiesLeftInWave--;
-        
+
         GameObject effect = Instantiate(deathEffect, transform.position, Quaternion.identity);
         Destroy(effect, 5f);
         Destroy(gameObject);
-  
+
     }
 
-    void Start()
-    {
+    void Start() {
         // Initialize Stats
         health = initHealth;
         speed = initSpeed;
@@ -214,18 +187,16 @@ public class Enemy : MonoBehaviour
 
         // first target, which is first waypoint in Waypoints
         target = Waypoints.points[0];
-        
+
         // get a reference to all cells for checking if a tile is fogged or not
         cells = GameObject.Find("Map").GetComponent<MapGenerator>().GetCells();
     }
 
 
-    void Update()
-    {
+    void Update() {
         healthText.text = string.Format("{0}", health);
 
-        if (health <= 0)
-        {
+        if (health <= 0) {
             Die();
         }
 
@@ -239,8 +210,7 @@ public class Enemy : MonoBehaviour
             return;
         }
 
-        if (isFrozen)
-        {
+        if (isFrozen) {
             // stop movement
             animator.SetBool("isWalking", false);
             return;
@@ -251,49 +221,43 @@ public class Enemy : MonoBehaviour
         // movement direction to the target waypoint
         Vector3 direction = target.position - transform.position;
 
-        if (direction != Vector3.zero)
-        {
+        if (direction != Vector3.zero) {
             // Do the rotation here
             Quaternion lookAtRotation = Quaternion.LookRotation(direction);
             Vector3 rotation = Quaternion.Lerp(model.transform.rotation, lookAtRotation, Time.deltaTime * 10f).eulerAngles;
             model.transform.rotation = Quaternion.Euler(rotation.x, rotation.y, rotation.z);
-        }        
+        }
 
         // delta time is time passed since last frame
         transform.Translate(direction.normalized * speed * Time.deltaTime, Space.World);
-        
+
         var currentPosition = transform.position;
 
-        if (Vector3.Distance(currentPosition, target.position) <= 0.2f)
-        {
+        if (Vector3.Distance(currentPosition, target.position) <= 0.2f) {
             GetNextWaypoint();
         }
 
         int currentXCoord = Convert.ToInt32(Math.Floor(currentPosition.x));
         int currentYCoord = Convert.ToInt32(Math.Floor(currentPosition.z));
 
-        if (currentXCoord != lastXCoord || currentYCoord != lastYCoord)
-        {
+        if (currentXCoord != lastXCoord || currentYCoord != lastYCoord) {
             lastXCoord = currentXCoord;
             lastYCoord = currentYCoord;
             isInFog = GetCurrentTileFogged(currentXCoord, currentYCoord);
         }
-        
+
         // enemy is visible if not in fog, hence its visibility is the negation of the isInFog bool.
         setEnemyVisibility(!isInFog);
-        
+
     }
 
-    private bool GetCurrentTileFogged(int xCoord, int yCoord)
-    {
+    private bool GetCurrentTileFogged(int xCoord, int yCoord) {
         Cell cell = cells[yCoord, xCoord];
         return cell.isFog;
     }
 
-    void GetNextWaypoint()
-    {
-        if (waypointIndex >= Waypoints.points.Length - 1) 
-        {
+    void GetNextWaypoint() {
+        if (waypointIndex >= Waypoints.points.Length - 1) {
             EndPath();
             return;
         }
@@ -302,30 +266,26 @@ public class Enemy : MonoBehaviour
     }
 
     // previously was enemy attack the base and destroy
-    void EndPath()
-    {
+    void EndPath() {
         // do nothing
         animator.SetBool("isWalking", false);
     }
 
-    private void setEnemyVisibility(bool isVisible)
-    {
+    private void setEnemyVisibility(bool isVisible) {
         //ballMeshRenderer.enabled = isVisible;
-        foreach (Transform childrenTransform in ballParentTransform)
-        {
+        foreach (Transform childrenTransform in ballParentTransform) {
             // disable canvas
             if (childrenTransform.name == canvas.name)
                 childrenTransform.gameObject.SetActive(isVisible);
 
             // disable every renderers
-            if (childrenTransform.name == model.name)
-            {
+            if (childrenTransform.name == model.name) {
                 SkinnedMeshRenderer[] renderers = model.GetComponentsInChildren<SkinnedMeshRenderer>();
                 foreach (SkinnedMeshRenderer r in renderers) {
                     r.enabled = isVisible;
                 }
             }
-              
+
         }
     }
 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -5,11 +5,11 @@ using TMPro;
 
 public class Enemy : MonoBehaviour {
 
-    [SerializeField] private float speed;               // Serialized for debugging purposes
+    [SerializeField] private float speed;
 
     [SerializeField] private float initSpeed = 1f;
 
-    [SerializeField] private float health;              // Serialized for debugging purposes
+    [SerializeField] private float health;
 
     [SerializeField] private float initHealth = 100;
 
@@ -31,7 +31,7 @@ public class Enemy : MonoBehaviour {
         drench, // water
         scald, // fire + water
         froze, // ice + water
-        weakened, // fire + ice
+        weaken, // fire + ice
         none // default
     }
 
@@ -48,14 +48,6 @@ public class Enemy : MonoBehaviour {
     public void removeEffectStatus() {
         effectStatus = EffectStatus.none;
     }
-
-
-    private bool isScorched = false; // fire: burnt
-    private bool isChilled = false; // ice
-    private bool isDrenched = false; // water: wet
-    private bool isScalded = false; // fire + water: vaporize
-    private bool isFrozen = false; // ice + water
-    private bool isWeakened = false; // fire + ice: melt
 
     public bool isInFog = true;
     //private MeshRenderer ballMeshRenderer;
@@ -128,46 +120,6 @@ public class Enemy : MonoBehaviour {
         defense = initDefense;
     }
 
-    public void setChilled(bool b) {
-        isChilled = b;
-    }
-
-    public bool getChilled() {
-        return isChilled;
-    }
-
-    public void setDrenched(bool b) {
-        isDrenched = b;
-    }
-
-    public bool getDrenched() {
-        return isDrenched;
-    }
-
-    public void setScalded(bool b) {
-        isScalded = b;
-    }
-
-    public bool getScalded() {
-        return isScalded;
-    }
-
-    public void setFrozen(bool b) {
-        isFrozen = b;
-    }
-
-    public bool getFrozen() {
-        return isFrozen;
-    }
-
-    public void setWeakened(bool b) {
-        isWeakened = b;
-    }
-
-    public bool getWeakened() {
-        return isWeakened;
-    }
-
     void Die() {
         // add ink
         inkManager.ChangeInkAmount(inkGained);
@@ -214,7 +166,7 @@ public class Enemy : MonoBehaviour {
 
         if (GetComponent<EnemyShooting>().isShooting) {
             // stop attack if frozen
-            if (isFrozen) GetComponent<EnemyShooting>().enabled = false;
+            if (getEffectStatus() == EffectStatus.froze) GetComponent<EnemyShooting>().enabled = false;
             // restore attack if not frozen
             else GetComponent<EnemyShooting>().enabled = true;
             // stop movement
@@ -222,7 +174,7 @@ public class Enemy : MonoBehaviour {
             return;
         }
 
-        if (isFrozen) {
+        if (getEffectStatus() == EffectStatus.froze) {
             // stop movement
             animator.SetBool("isWalking", false);
             return;

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -122,7 +122,7 @@ public class Enemy : MonoBehaviour {
         defense = initDefense;
     }
 
-    void Die() {
+    private void Die() {
         // add ink
         inkManager.ChangeInkAmount(inkGained);
 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -3,6 +3,19 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 
+/** 
+ * Enemy's effect status caused by element reactions
+ */
+public enum EffectStatus {
+    SCORCH, // fire
+    CHILL, // ice
+    DRENCH, // water
+    SCALD, // fire + water
+    FROZE, // ice + water
+    WEAKEN, // fire + ice
+    NONE // default
+}
+
 public class Enemy : MonoBehaviour {
 
     /**
@@ -17,19 +30,7 @@ public class Enemy : MonoBehaviour {
     [SerializeField] private float inkGained = 1f;
     [SerializeField] private GameObject deathEffect;
 
-    /** 
-     * Effect status
-     */
-    public enum EffectStatus {
-        SCORCH, // fire
-        CHILL, // ice
-        DRENCH, // water
-        SCALD, // fire + water
-        FROZE, // ice + water
-        WEAKEN, // fire + ice
-        NONE // default
-    }
-    public EffectStatus effectStatus = EffectStatus.NONE;
+    public EffectStatus effectStatus;
     public void setEffectStatus(EffectStatus status) {
         effectStatus = status;
     }
@@ -139,6 +140,7 @@ public class Enemy : MonoBehaviour {
         health = initHealth;
         speed = initSpeed;
         defense = initDefense;
+        effectStatus = EffectStatus.NONE;
         bulletPrefab = GetComponentInParent<EnemyShooting>().bulletPrefab;
 
         model = transform.GetChild(2).gameObject;

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -21,15 +21,15 @@ public class Enemy : MonoBehaviour {
      * Effect status
      */
     public enum EffectStatus {
-        scorch, // fire
-        chill, // ice
-        drench, // water
-        scald, // fire + water
-        froze, // ice + water
-        weaken, // fire + ice
-        none // default
+        SCORCH, // fire
+        CHILL, // ice
+        DRENCH, // water
+        SCALD, // fire + water
+        FROZE, // ice + water
+        WEAKEN, // fire + ice
+        NONE // default
     }
-    public EffectStatus effectStatus = EffectStatus.none;
+    public EffectStatus effectStatus = EffectStatus.NONE;
     public void setEffectStatus(EffectStatus status) {
         effectStatus = status;
     }
@@ -37,7 +37,7 @@ public class Enemy : MonoBehaviour {
         return effectStatus;
     }
     public void removeEffectStatus() {
-        effectStatus = EffectStatus.none;
+        effectStatus = EffectStatus.NONE;
     }
 
     /**
@@ -162,14 +162,14 @@ public class Enemy : MonoBehaviour {
         }
 
         if (GetComponent<EnemyShooting>().isShooting) {
-            if (getEffectStatus() == EffectStatus.froze) GetComponent<EnemyShooting>().enabled = false;
+            if (getEffectStatus() == EffectStatus.FROZE) GetComponent<EnemyShooting>().enabled = false;
             else GetComponent<EnemyShooting>().enabled = true;
             // stop movement
             animator.SetBool("isWalking", false);
             return;
         }
 
-        if (getEffectStatus() == EffectStatus.froze) {
+        if (getEffectStatus() == EffectStatus.FROZE) {
             animator.SetBool("isWalking", false);
             return;
         }

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -5,26 +5,21 @@ using TMPro;
 
 public class Enemy : MonoBehaviour {
 
+    /**
+     * enemy properties 
+     */
     [SerializeField] private float speed;
-
     [SerializeField] private float initSpeed = 1f;
-
     [SerializeField] private float health;
-
     [SerializeField] private float initHealth = 100;
-
     [SerializeField] private int defense;
-
     [SerializeField] private int initDefense = 10;
-
     [SerializeField] private float inkGained = 1f;
-
-
     [SerializeField] private GameObject deathEffect;
 
-    private InkManager inkManager;
-
-    // Flags for status effects
+    /** 
+     * Effect status
+     */
     public enum EffectStatus {
         scorch, // fire
         chill, // ice
@@ -34,44 +29,50 @@ public class Enemy : MonoBehaviour {
         weaken, // fire + ice
         none // default
     }
-
     public EffectStatus effectStatus = EffectStatus.none;
-
     public void setEffectStatus(EffectStatus status) {
         effectStatus = status;
     }
-
     public EffectStatus getEffectStatus() {
         return effectStatus;
     }
-
     public void removeEffectStatus() {
         effectStatus = EffectStatus.none;
     }
 
+    /**
+     * Visibility
+     */
     public bool isInFog = true;
-    //private MeshRenderer ballMeshRenderer;
     private Transform ballParentTransform;
+    public Canvas canvas;
 
+    /**
+     * Shoot target
+     */
     private Transform target;
-    private int waypointIndex = 0;
+    private GameObject bulletPrefab;
 
+    /**
+     * Rotation
+     */
+    public GameObject model;
+    public Animator animator;
+
+    /**
+     * Translation
+     */
+    private int waypointIndex = 0;
     private int lastXCoord = 0;
     private int lastYCoord = 0;
+    public MapGenerator map;
+    private Cell[,] cells;
 
-    // to reduce bullet damage
-    private GameObject bulletPrefab;
+    private InkManager inkManager;
 
     [Header("Unity Stuff")]
     public Image healthBar;
     public TMP_Text healthText;
-
-    public MapGenerator map;
-    private Cell[,] cells;
-
-    public GameObject model;
-    public Animator animator;
-    public Canvas canvas;
 
     private void Awake() {
         inkManager = InkManager.instance;
@@ -135,18 +136,14 @@ public class Enemy : MonoBehaviour {
     }
 
     void Start() {
-        // Initialize Stats
         health = initHealth;
         speed = initSpeed;
         defense = initDefense;
         bulletPrefab = GetComponentInParent<EnemyShooting>().bulletPrefab;
 
-        // initialize model and animator
         model = transform.GetChild(2).gameObject;
         animator = model.GetComponent<Animator>();
         canvas = transform.GetChild(0).GetComponent<Canvas>();
-
-        //ballMeshRenderer = gameObject.GetComponent<MeshRenderer>();
         ballParentTransform = gameObject.transform;
 
         // first target, which is first waypoint in Waypoints
@@ -165,9 +162,7 @@ public class Enemy : MonoBehaviour {
         }
 
         if (GetComponent<EnemyShooting>().isShooting) {
-            // stop attack if frozen
             if (getEffectStatus() == EffectStatus.froze) GetComponent<EnemyShooting>().enabled = false;
-            // restore attack if not frozen
             else GetComponent<EnemyShooting>().enabled = true;
             // stop movement
             animator.SetBool("isWalking", false);
@@ -175,7 +170,6 @@ public class Enemy : MonoBehaviour {
         }
 
         if (getEffectStatus() == EffectStatus.froze) {
-            // stop movement
             animator.SetBool("isWalking", false);
             return;
         }
@@ -229,14 +223,11 @@ public class Enemy : MonoBehaviour {
         target = Waypoints.points[waypointIndex];
     }
 
-    // previously was enemy attack the base and destroy
     void EndPath() {
-        // do nothing
         animator.SetBool("isWalking", false);
     }
 
     private void setEnemyVisibility(bool isVisible) {
-        //ballMeshRenderer.enabled = isVisible;
         foreach (Transform childrenTransform in ballParentTransform) {
             // disable canvas
             if (childrenTransform.name == canvas.name)


### PR DESCRIPTION
- Use enum `EffectStatus` to keep track of enemy status caused by element effects.
- provide functions such as `setEffectStatus(EffectStatus)`, `getEffectStatus()` and `removeEffectStatus()` 
- refactor enemy script. Next PR: implement Scriptable Objects for enemy

Can be tested on `TowerRefactor` scene with ink auto generation to test out every element combinations.

This PR is not refactoring `ElementEffectsSystem/EffectManager`