### PR TITLE
Debug spikey tower bullet not shown

### DIFF
--- a/Assets/DeveloperGuide.meta
+++ b/Assets/DeveloperGuide.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c0adb3ca906b4f7ea36a3f7e57ff72d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/DeveloperGuide/public.meta
+++ b/Assets/DeveloperGuide/public.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ed26d90035584186ac045f98c9cbb6a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyBase.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyBase.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   element: {fileID: 0}
   cost: 100
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
   damage: 30
   penetratesEnemy: 0

--- a/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyFire.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyFire.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   element: {fileID: 11400000, guid: 5503097e096315346a110e0488d9c960, type: 2}
   cost: 75
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
   damage: 20
   penetratesEnemy: 0

--- a/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyIce.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyIce.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   element: {fileID: 11400000, guid: 2a9f0209ebf96cc4f8a2c63413522b7e, type: 2}
   cost: 75
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
   damage: 25
   penetratesEnemy: 0

--- a/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyWater.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/0_SpikeyWater.asset
@@ -19,7 +19,7 @@ MonoBehaviour:
   element: {fileID: 11400000, guid: 5f2ac61151ef7e347b4a722691241670, type: 2}
   cost: 75
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
   damage: 25
   penetratesEnemy: 0

--- a/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyBase.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyBase.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   element: {fileID: 0}
   cost: 150
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
-  damage: 0
+  damage: 36
   penetratesEnemy: 0
   impactPrefab: {fileID: 0}
   towerPrefab: {fileID: 5135174605016635187, guid: 4d28ac568c6555345afb90b3d507984d, type: 3}

--- a/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyFire.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyFire.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   element: {fileID: 11400000, guid: 5503097e096315346a110e0488d9c960, type: 2}
   cost: 75
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
-  damage: 0
+  damage: 24
   penetratesEnemy: 0
   impactPrefab: {fileID: 0}
   towerPrefab: {fileID: 5135174605016635187, guid: 335d76b7c46f8b04aa0877f9b04ab4c7, type: 3}

--- a/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyIce.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyIce.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   element: {fileID: 11400000, guid: 2a9f0209ebf96cc4f8a2c63413522b7e, type: 2}
   cost: 75
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
-  damage: 0
+  damage: 30
   penetratesEnemy: 0
   impactPrefab: {fileID: 0}
   towerPrefab: {fileID: 5135174605016635187, guid: 6fc7a5ea2c8c90c4c8e65cdecbdc9776, type: 3}

--- a/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyWater.asset
+++ b/Assets/ScriptableObjects/Towers/Spikey/1_SpikeyWater.asset
@@ -19,9 +19,9 @@ MonoBehaviour:
   element: {fileID: 11400000, guid: 5f2ac61151ef7e347b4a722691241670, type: 2}
   cost: 75
   allowedCellTypes: 00000000
-  speed: 0
+  speed: 1
   explosionRadius: 0
-  damage: 0
+  damage: 30
   penetratesEnemy: 0
   impactPrefab: {fileID: 0}
   towerPrefab: {fileID: 5135174605016635187, guid: 75dbd8ccc311a6f4dab53631f7d0fcb6, type: 3}


### PR DESCRIPTION
This PR is a bug fix for spikey tower bullets not shown when the enemy is near.

Error:
- `Speed` variable of respective Spikey Tower Scriptable Object is not set.

Addition:
- Updated respective Spikey Tower's specs according to [documentation](https://docs.google.com/document/d/1EMWuQQtFr3Q6takw9Fw6lqvzjAYvb_Wlp3NStnruTic/edit?usp=sharing).