### PR TITLE
Debug gel tower upgrade btn

### DIFF
--- a/Assets/ScriptableObjects/Towers/Ballista/0_BallistaIce.asset
+++ b/Assets/ScriptableObjects/Towers/Ballista/0_BallistaIce.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02acc0fa88f06934f9c8db381de21961, type: 3}
   m_Name: 0_BallistaIce
   m_EditorClassIdentifier: 
-  towerName: Fire Ballista
+  towerName: Ice Ballista
   towerDesc: 
   range: 3
   upgradeNum: 0

--- a/Assets/ScriptableObjects/Towers/Ballista/0_BallistaWater.asset
+++ b/Assets/ScriptableObjects/Towers/Ballista/0_BallistaWater.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02acc0fa88f06934f9c8db381de21961, type: 3}
   m_Name: 0_BallistaWater
   m_EditorClassIdentifier: 
-  towerName: Fire Ballista
+  towerName: Water Ballista
   towerDesc: 
   range: 3
   upgradeNum: 0

--- a/Assets/ScriptableObjects/Towers/Ballista/1_BallistaIce.asset
+++ b/Assets/ScriptableObjects/Towers/Ballista/1_BallistaIce.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02acc0fa88f06934f9c8db381de21961, type: 3}
   m_Name: 1_BallistaIce
   m_EditorClassIdentifier: 
-  towerName: Fire Ballista
+  towerName: Ice Ballista
   towerDesc: 
   range: 3
   upgradeNum: 1

--- a/Assets/ScriptableObjects/Towers/Ballista/1_BallistaWater.asset
+++ b/Assets/ScriptableObjects/Towers/Ballista/1_BallistaWater.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02acc0fa88f06934f9c8db381de21961, type: 3}
   m_Name: 1_BallistaWater
   m_EditorClassIdentifier: 
-  towerName: Fire Ballista
+  towerName: Water Ballista
   towerDesc: 
   range: 3
   upgradeNum: 1

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelBase.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelBase.asset
@@ -25,9 +25,7 @@ MonoBehaviour:
     $25, +20% DMG and Explode Radius
 
     Arrows explode on impact, small AOE damage,
-    AOE slow
-
-'
+    AOE slow.'
   range: 4
   upgradeNum: 0
   fireRate: 1

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelFire.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelFire.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.75
   damageFixCost: 0
   damageFixFactor: 0.25
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1
   damage: 12

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelIce.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelIce.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.75
   damageFixCost: 0
   damageFixFactor: 0.25
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1
   damage: 15

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelWater.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/0_GelWater.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.75
   damageFixCost: 0
   damageFixFactor: 0.25
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1
   damage: 15

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelBase.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelBase.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   towerName: Gel Explosion
   towerDesc: 
   range: 3
-  upgradeNum: 0
+  upgradeNum: 1
   fireRate: 1
   element: {fileID: 0}
   cost: 35
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.7
   damageFixCost: 0
   damageFixFactor: 0.2
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1.2
   damage: 24

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelFire.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelFire.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   towerName: Fire Gel Explosion
   towerDesc: 
   range: 3
-  upgradeNum: 0
+  upgradeNum: 1
   fireRate: 1
   element: {fileID: 11400000, guid: 5503097e096315346a110e0488d9c960, type: 2}
   cost: 40
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.7
   damageFixCost: 0
   damageFixFactor: 0.2
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1.2
   damage: 15

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelIce.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelIce.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   towerName: Ice Gel Explosion
   towerDesc: 
   range: 3
-  upgradeNum: 0
+  upgradeNum: 1
   fireRate: 1
   element: {fileID: 11400000, guid: 2a9f0209ebf96cc4f8a2c63413522b7e, type: 2}
   cost: 40
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.7
   damageFixCost: 0
   damageFixFactor: 0.2
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1.2
   damage: 18

--- a/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelWater.asset
+++ b/Assets/ScriptableObjects/Towers/Gel Explosion/1_GelWater.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   towerName: Water Gel Explosion
   towerDesc: 
   range: 3
-  upgradeNum: 0
+  upgradeNum: 1
   fireRate: 1
   element: {fileID: 11400000, guid: 5f2ac61151ef7e347b4a722691241670, type: 2}
   cost: 40
@@ -23,7 +23,7 @@ MonoBehaviour:
   healthDecayRate: 1.7
   damageFixCost: 0
   damageFixFactor: 0.2
-  allowedCellTypes: 
+  allowedCellTypes: 00000000
   speed: 30
   explosionRadius: 1.2
   damage: 18

--- a/Assets/Scripts/UI/Tooltip/NodeUITooltipTrigger.cs
+++ b/Assets/Scripts/UI/Tooltip/NodeUITooltipTrigger.cs
@@ -20,7 +20,6 @@ public class NodeUITooltipTrigger : TooltipTrigger {
         if (!newTower || !currentTower || isFixButton) return content;
         int damageDiff = newTower.damage - currentTower.damage;
         float rangeDiff = newTower.range - currentTower.range;
-
         string effect = isUpgrade ? $"Upgrade to level {newTower.upgradeNum}" : $"Effect: {newTower.element.effect.Name}";
         string pattern = $"{effect}\nDMG: {newTower.damage} [{damageDiff}]\nRange: {newTower.range} [{rangeDiff}]";
         return pattern;


### PR DESCRIPTION
- Error: `NullReferenceException` when the mouse hovers over the tower `upgrade` button, causing tooltip information not to be shown.
- Solution: For upgraded towers, for each of their respective scriptable objects, `upgradeNum` should be set to `1`.