### PR TITLE
Fix spider-dialog text invisible

### DIFF
--- a/Assets/Scenes/Dialogues/Spiders_Theme/Scripts/DialogueSystemManager.cs
+++ b/Assets/Scenes/Dialogues/Spiders_Theme/Scripts/DialogueSystemManager.cs
@@ -56,7 +56,6 @@ namespace Yarn.Unity.Example {
         private void Update() {
             if (FindObjectOfType<DialogueRunner>().IsDialogueRunning == false) {
                 GotoButton.gameObject.SetActive(true);
-                return;
             }
         }
 


### PR DESCRIPTION
test on editor & windows build: 
tutorial dialog -> tutorial level -> spider dialog (see if text is shown) -> spider level (see if level playable)