### PR TITLE
Fix buttons on WinScreen and GameOverScreen

### DIFF
--- a/Assets/Scenes/Levels/ClownScene-beta.unity
+++ b/Assets/Scenes/Levels/ClownScene-beta.unity
@@ -1061,6 +1061,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6600273765387948035}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoNextScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameStateManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 378319769803560576, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2566,6 +2594,7 @@ MonoBehaviour:
   numEnemiesLeftInWave: 0
   isSpawningEnemy: 0
   waves: []
+  timeBetweenWaves: 10
 --- !u!1 &1458396411 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4600644439624492359, guid: 6976bd883f3cfbf4e93c609cb365af3c, type: 3}
@@ -3038,7 +3067,7 @@ PrefabInstance:
       objectReference: {fileID: 476527617}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: nextSceneName
-      value: spider_theme_dialogue
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: wavesCounterUI
@@ -3123,6 +3152,17 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6600273765185839075, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+--- !u!114 &6600273765387948035 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+  m_PrefabInstance: {fileID: 6600273765387948034}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1896366525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &6600273765387948036 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2930312957552281026, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}

--- a/Assets/Scenes/Levels/ClownScene-beta.unity
+++ b/Assets/Scenes/Levels/ClownScene-beta.unity
@@ -1072,18 +1072,18 @@ PrefabInstance:
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 6600273765387948035}
+      objectReference: {fileID: 476527621}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: GotoNextScene
+      value: GotoMainMenu
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameStateManager, Assembly-CSharp
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -1217,6 +1217,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3458236377440584164, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3609295152533398961, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1333,6 +1337,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3944042296333450208, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0
+      objectReference: {fileID: 0}
     - target: {fileID: 4078675094712855791, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1376,6 +1384,10 @@ PrefabInstance:
     - target: {fileID: 4202064417956510977, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
@@ -1485,6 +1497,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6185660578774322227, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131555, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
+      objectReference: {fileID: 0}
     - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
       value: 
@@ -1504,6 +1528,18 @@ PrefabInstance:
     - target: {fileID: 6528092713535694324, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 476527620}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7390242602115321821, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_Volume
@@ -1618,6 +1654,10 @@ PrefabInstance:
       value: MainUI
       objectReference: {fileID: 0}
     - target: {fileID: 7889651949126038101, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8150869651247243699, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
@@ -1806,6 +1846,28 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7889651949126038101, guid: 636b4af0198ef8246beebccec196472b, type: 3}
   m_PrefabInstance: {fileID: 476527616}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &476527620 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 476527616}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476527617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &476527621 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 476527616}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476527618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &557443432
 GameObject:
   m_ObjectHideFlags: 0
@@ -3152,17 +3214,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6600273765185839075, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
---- !u!114 &6600273765387948035 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
-  m_PrefabInstance: {fileID: 6600273765387948034}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1896366525}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6600273765387948036 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2930312957552281026, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}

--- a/Assets/Scenes/Levels/ClownScene-beta.unity
+++ b/Assets/Scenes/Levels/ClownScene-beta.unity
@@ -1385,6 +1385,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5202906098347979621, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_Text
+      value: Menu
+      objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: mainMenuScene
       value: Menu-beta

--- a/Assets/Scenes/Levels/GhostScene-beta.unity
+++ b/Assets/Scenes/Levels/GhostScene-beta.unity
@@ -1557,6 +1557,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6600273765387948035}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoNextScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameStateManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 378319769803560576, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2739,6 +2767,7 @@ MonoBehaviour:
   numEnemiesLeftInWave: 0
   isSpawningEnemy: 0
   waves: []
+  timeBetweenWaves: 10
 --- !u!1 &1458396411 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4600644439624492359, guid: 6976bd883f3cfbf4e93c609cb365af3c, type: 3}
@@ -3110,7 +3139,7 @@ PrefabInstance:
       objectReference: {fileID: 827046482}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: nextSceneName
-      value: spider_theme_dialogue
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: wavesCounterUI
@@ -3195,6 +3224,17 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6600273765185839075, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+--- !u!114 &6600273765387948035 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+  m_PrefabInstance: {fileID: 6600273765387948034}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 240270875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &6600273765387948036 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2930312957552281026, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}

--- a/Assets/Scenes/Levels/GhostScene-beta.unity
+++ b/Assets/Scenes/Levels/GhostScene-beta.unity
@@ -1869,6 +1869,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5202906098347979621, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_Text
+      value: Menu
+      objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: mainMenuScene
       value: Menu-beta

--- a/Assets/Scenes/Levels/GhostScene-beta.unity
+++ b/Assets/Scenes/Levels/GhostScene-beta.unity
@@ -1568,18 +1568,18 @@ PrefabInstance:
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 6600273765387948035}
+      objectReference: {fileID: 827046486}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: GotoNextScene
+      value: GotoMainMenu
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameStateManager, Assembly-CSharp
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -1709,6 +1709,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3458236377440584164, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3609295152533398961, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1820,6 +1824,10 @@ PrefabInstance:
     - target: {fileID: 3609295154201961670, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3944042296333450208, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4078675094712855791, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1860,6 +1868,10 @@ PrefabInstance:
     - target: {fileID: 4202064417956510977, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
@@ -1969,6 +1981,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6185660578774322227, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131555, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
+      objectReference: {fileID: 0}
     - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
       value: 
@@ -1988,6 +2012,18 @@ PrefabInstance:
     - target: {fileID: 6528092713535694324, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 827046485}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7390242602115321821, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_Volume
@@ -2286,6 +2322,28 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7889651949126038101, guid: 636b4af0198ef8246beebccec196472b, type: 3}
   m_PrefabInstance: {fileID: 827046481}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &827046485 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 827046481}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 827046482}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &827046486 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 827046481}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 827046483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1222743743 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8448678081358125985, guid: 6976bd883f3cfbf4e93c609cb365af3c, type: 3}
@@ -3224,17 +3282,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6600273765185839075, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
---- !u!114 &6600273765387948035 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
-  m_PrefabInstance: {fileID: 6600273765387948034}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 240270875}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6600273765387948036 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2930312957552281026, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}

--- a/Assets/Scenes/Levels/SpiderScene-beta.unity
+++ b/Assets/Scenes/Levels/SpiderScene-beta.unity
@@ -1524,18 +1524,18 @@ PrefabInstance:
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 6600273765387948035}
+      objectReference: {fileID: 827046487}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: GotoNextScene
+      value: GotoMainMenu
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameStateManager, Assembly-CSharp
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -1669,6 +1669,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3458236377440584164, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3609295152533398961, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1780,6 +1784,10 @@ PrefabInstance:
     - target: {fileID: 3609295154201961670, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3944042296333450208, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 4078675094712855791, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1820,6 +1828,10 @@ PrefabInstance:
     - target: {fileID: 4202064417956510977, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
@@ -1929,6 +1941,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6185660578774322227, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131555, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
+      objectReference: {fileID: 0}
     - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
       value: 
@@ -1948,6 +1972,18 @@ PrefabInstance:
     - target: {fileID: 6528092713535694324, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 827046486}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7390242602115321821, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_Volume
@@ -2251,6 +2287,28 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6087580708587138388, guid: 636b4af0198ef8246beebccec196472b, type: 3}
   m_PrefabInstance: {fileID: 827046481}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &827046486 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 827046481}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 827046482}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &827046487 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 827046481}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 827046483}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1222743743 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8448678081358125985, guid: 6976bd883f3cfbf4e93c609cb365af3c, type: 3}
@@ -3310,17 +3368,6 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6600273765185839075, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
---- !u!114 &6600273765387948035 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
-  m_PrefabInstance: {fileID: 6600273765387948034}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1445912336}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &6600273765387948036 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2930312957552281026, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}

--- a/Assets/Scenes/Levels/SpiderScene-beta.unity
+++ b/Assets/Scenes/Levels/SpiderScene-beta.unity
@@ -1513,6 +1513,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6600273765387948035}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoNextScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameStateManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 188956860012959090, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: towerInfo
       value: 
@@ -2612,6 +2640,7 @@ MonoBehaviour:
   numEnemiesLeftInWave: 0
   isSpawningEnemy: 0
   waves: []
+  timeBetweenWaves: 10
 --- !u!1 &1445912336 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6600273765185839068, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
@@ -3196,7 +3225,7 @@ PrefabInstance:
       objectReference: {fileID: 827046482}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: nextSceneName
-      value: spider_theme_dialogue
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: wavesCounterUI
@@ -3281,6 +3310,17 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 6600273765185839075, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+--- !u!114 &6600273765387948035 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+  m_PrefabInstance: {fileID: 6600273765387948034}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1445912336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &6600273765387948036 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2930312957552281026, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}

--- a/Assets/Scenes/Levels/SpiderScene-beta.unity
+++ b/Assets/Scenes/Levels/SpiderScene-beta.unity
@@ -1829,6 +1829,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5202906098347979621, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_Text
+      value: Menu
+      objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: mainMenuScene
       value: Menu-beta

--- a/Assets/Scenes/Levels/TutorialScene-beta.unity
+++ b/Assets/Scenes/Levels/TutorialScene-beta.unity
@@ -2336,6 +2336,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5202906098347979621, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_Text
+      value: Menu
+      objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: mainMenuScene
       value: Menu-beta

--- a/Assets/Scenes/Levels/TutorialScene-beta.unity
+++ b/Assets/Scenes/Levels/TutorialScene-beta.unity
@@ -1879,6 +1879,7 @@ MonoBehaviour:
   numEnemiesLeftInWave: 0
   isSpawningEnemy: 0
   waves: []
+  timeBetweenWaves: 10
 --- !u!1 &1458396411 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4600644439624492359, guid: 6976bd883f3cfbf4e93c609cb365af3c, type: 3}
@@ -2002,6 +2003,34 @@ PrefabInstance:
     - target: {fileID: 116468941672033193, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6600273765387948039}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoNextScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameStateManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 378319769803560576, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2937,7 +2966,7 @@ PrefabInstance:
       objectReference: {fileID: 1555788714}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: nextSceneName
-      value: spider_theme_dialogue
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
       propertyPath: wavesCounterUI
@@ -3134,6 +3163,17 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!114 &6600273765387948039 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
+  m_PrefabInstance: {fileID: 6600273765387948034}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6600273765387948035}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7828996251632798773
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/TutorialScene-beta.unity
+++ b/Assets/Scenes/Levels/TutorialScene-beta.unity
@@ -2015,18 +2015,18 @@ PrefabInstance:
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 6600273765387948039}
+      objectReference: {fileID: 1555788718}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: GotoNextScene
+      value: GotoMainMenu
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameStateManager, Assembly-CSharp
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 157767887926934042, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -2128,6 +2128,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2230814366470999922, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1555788717}
+    - target: {fileID: 2230814366470999922, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Retry
+      objectReference: {fileID: 0}
+    - target: {fileID: 2230814366470999922, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameOverManager, Assembly-CSharp
+      objectReference: {fileID: 0}
     - target: {fileID: 2523807561363963142, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2159,6 +2171,10 @@ PrefabInstance:
     - target: {fileID: 2768851690306522593, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3458236377440584164, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3609295152533398961, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
@@ -2276,6 +2292,10 @@ PrefabInstance:
       propertyPath: spellInfo
       value: 
       objectReference: {fileID: 11400000, guid: 162ca779588bc3b45b3fcfd478821953, type: 2}
+    - target: {fileID: 3944042296333450208, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 4078675094712855791, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2315,6 +2335,10 @@ PrefabInstance:
     - target: {fileID: 4202064417956510977, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
       objectReference: {fileID: 0}
     - target: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
@@ -2424,6 +2448,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6185660578774322227, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131555, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: mainMenuScene
+      value: Menu-beta
+      objectReference: {fileID: 0}
     - target: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: raycastOccluder
       value: 
@@ -2443,6 +2479,18 @@ PrefabInstance:
     - target: {fileID: 6528092713535694324, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1555788717}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GotoMainMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 7046791423859815493, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameOverManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 7390242602115321821, guid: 636b4af0198ef8246beebccec196472b, type: 3}
       propertyPath: m_Volume
@@ -2757,6 +2805,28 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7889651949126038101, guid: 636b4af0198ef8246beebccec196472b, type: 3}
   m_PrefabInstance: {fileID: 1555788713}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1555788717 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6212984491611131557, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 1555788713}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555788714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1555788718 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5215887617002473692, guid: 636b4af0198ef8246beebccec196472b, type: 3}
+  m_PrefabInstance: {fileID: 1555788713}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555788715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1967037e59a1c245a40bec85163e698, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1789031178 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7828996249860865855, guid: f4e9a02ecb6b9ac48a0cbcf1e9a649a0, type: 3}
@@ -3163,17 +3233,6 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &6600273765387948039 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6600273765185839073, guid: 737c34c281d203e49a385a75b0cfbb8d, type: 3}
-  m_PrefabInstance: {fileID: 6600273765387948034}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6600273765387948035}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4b52799cdd58d584686b6444020408c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &7828996251632798773
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager/GameOverManager.cs
+++ b/Assets/Scripts/GameManager/GameOverManager.cs
@@ -3,10 +3,12 @@ using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Collections;
 
+/** Used by WinScreen and GameOverScreen
+ */
 public class GameOverManager : MonoBehaviour {
+    public string mainMenuScene;
     public Text wavesText;
     public GameObject raycastOccluder;
-    public string retrySceneName;
 
     // Enabled when game is running
     void OnEnable() {
@@ -27,22 +29,17 @@ public class GameOverManager : MonoBehaviour {
 
         // pause
         Time.timeScale = 0f;
-
     }
 
     public void Retry() {
-        // load current active scene
-        // deprecated: SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
-
-        GameObject[] ddols = GameStateManager.GetDontDestroyOnLoadObjects();
-        for (int i = 0; i < ddols.Length; i++) {
-            Destroy(ddols[i]);
-        }
-
-        SceneManager.LoadScene(retrySceneName);
-
-        // remove occluder
-        raycastOccluder.SetActive(false);
+        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
         Time.timeScale = 1f;
+        raycastOccluder.SetActive(false);
+    }
+
+    public void GotoMainMenu() {
+        SceneManager.LoadScene(mainMenuScene);
+        Time.timeScale = 1f;
+        raycastOccluder.SetActive(false);
     }
 }

--- a/Assets/Scripts/GameManager/GameOverManager.cs
+++ b/Assets/Scripts/GameManager/GameOverManager.cs
@@ -19,10 +19,6 @@ public class GameOverManager : MonoBehaviour {
 
         StartCoroutine(PauseGame());
 
-        GameObject[] ddols = GameStateManager.GetDontDestroyOnLoadObjects();
-        for (int i = 0; i < ddols.Length; i++) {
-            Destroy(ddols[i]);
-        }
     }
 
     IEnumerator PauseGame() {

--- a/Assets/Scripts/GameManager/GameStateManager.cs
+++ b/Assets/Scripts/GameManager/GameStateManager.cs
@@ -1,10 +1,8 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class GameStateManager : MonoBehaviour {
     [SerializeField] private GameObject gameOverUI;
     [SerializeField] private GameObject winUI;
-    public string nextSceneName;
 
     private static bool isGameEnded;
     private Map map;
@@ -12,13 +10,6 @@ public class GameStateManager : MonoBehaviour {
     void Start() {
         isGameEnded = false;
         map = FindObjectOfType<Map>();
-
-        /*
-        GameObject[] ddols = GetDontDestroyOnLoadObjects();
-        for (int i = 0; i < ddols.Length; i++) {
-            ddols[i].transform.Find(LoadingUI.loadingUIName).gameObject.SetActive(false);
-        }
-        */
     }
 
     void Update() {
@@ -32,27 +23,12 @@ public class GameStateManager : MonoBehaviour {
 
     public void EndGame() {
         isGameEnded = true;
-
         gameOverUI.SetActive(true);
     }
 
     public void WinGame() {
-        /*GameObject[] ddols = GetDontDestroyOnLoadObjects();
-        for (int i = 0; i < ddols.Length; i++) {
-            ddols[i].SetActive(false);
-        }*/
-
         isGameEnded = true;
-
         winUI.SetActive(true);
-    }
-
-    public void GotoNextScene() {
-        /*GameObject[] ddols = GetDontDestroyOnLoadObjects();
-        for (int i = 0; i < ddols.Length; i++) {
-            Destroy(ddols[i]);
-        }*/
-        SceneManager.LoadScene(nextSceneName);
     }
 
     // for other game scripts to check if the game is ended
@@ -75,4 +51,5 @@ public class GameStateManager : MonoBehaviour {
                 Object.DestroyImmediate(temp);
         }
     }
+
 }

--- a/Assets/Scripts/GameManager/GameStateManager.cs
+++ b/Assets/Scripts/GameManager/GameStateManager.cs
@@ -37,10 +37,10 @@ public class GameStateManager : MonoBehaviour {
     }
 
     public void WinGame() {
-        GameObject[] ddols = GetDontDestroyOnLoadObjects();
+        /*GameObject[] ddols = GetDontDestroyOnLoadObjects();
         for (int i = 0; i < ddols.Length; i++) {
             ddols[i].SetActive(false);
-        }
+        }*/
 
         isGameEnded = true;
 
@@ -48,10 +48,10 @@ public class GameStateManager : MonoBehaviour {
     }
 
     public void GotoNextScene() {
-        GameObject[] ddols = GetDontDestroyOnLoadObjects();
+        /*GameObject[] ddols = GetDontDestroyOnLoadObjects();
         for (int i = 0; i < ddols.Length; i++) {
             Destroy(ddols[i]);
-        }
+        }*/
         SceneManager.LoadScene(nextSceneName);
     }
 


### PR DESCRIPTION
winscreen having a menu button to `Menu-beta`
gameOverScreen having retry and menu buttons:
- retry to replay the level
- menu to `Menu-beta`

![image](https://user-images.githubusercontent.com/58804560/197154852-f1d0b6b9-ab21-4e58-8125-ca4d5488e2a0.png)
![image](https://user-images.githubusercontent.com/58804560/197154953-ac0bcde5-9e83-4d82-a79f-3f69970fc704.png)

Implementation:
WinScreen & GameOverScreen to continue having GameOverManager. Both of the screens will have buttons to call methods in the manager. Remove the scene handling in GameStateManager.

